### PR TITLE
Fix font-size, add max-height, reduce z-index

### DIFF
--- a/src/fancyselect.css
+++ b/src/fancyselect.css
@@ -3,7 +3,7 @@
   --fsb-radius: 5px;
   --fsb-color: inherit;
   --fsb-background: #fff;
-  --fsb-font-size: 1em;
+  --fsb-font-size: 1rem;
   --fsb-shadow: 0 1px 1px rgba(0, 0, 0, .1);
   --fsb-padding: 8px;
   --fsb-padding-right: var(--fsb-padding);
@@ -157,7 +157,7 @@ select[disabled] + .fsb-select .fsb-list {
   margin: 0;
   left: 0;
   top: 100%;
-  z-index: 1000;
+  z-index: 1;
   padding: 0;
   border: inherit;
   border: var(--fsb-list-border);
@@ -181,7 +181,8 @@ select[disabled] + .fsb-select .fsb-list {
 }
 
 .fsb-button[aria-expanded="true"] + .fsb-list {
-  height: var(--fsb-list-height);
+  height: auto;
+  max-height: var(--fsb-list-height);
   visibility: visible;
   opacity: 1;
 }


### PR DESCRIPTION
Replaced font-size from em to rem. Otherwise inheritance from parent could make the font-size in select too big e.g.
Changed height to auto and added max-height in case of small amount of options. Now the select options' container is too long if there is not too many options.
Reduced z-index to avoid possible overlappings with existing styles of any project.